### PR TITLE
replaced outdated bash command seq with {x..y} range

### DIFF
--- a/03#long_running_jobs/long_running_job.sh
+++ b/03#long_running_jobs/long_running_job.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-for count in `seq 1 100`; do
+for count in {1..100}; do
     echo $count
     sleep 0.1
 done

--- a/04#progress/bin/job.sh
+++ b/04#progress/bin/job.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-for count in `seq 1 100`; do
+for count in {1..100}; do
     echo $count
     sleep 0.1
 done


### PR DESCRIPTION
Ciao,
stavo dando un'occhiata ai tuoi esempi e l'esempio 3 e 4 non mi funzionavano.
Sto usando osx che ha la GNU bash, version 3.2.48 e il comando seq non esiste perché è considerato "antiquato". Ho quindi utilizzato for i in {1..100} e il tutto funziona correttamente.

cirpo
